### PR TITLE
Switch Alchemy to use only one api key.

### DIFF
--- a/apps/backend/.env.sample
+++ b/apps/backend/.env.sample
@@ -5,12 +5,7 @@ PROD_URL="https://ize.space"
 PROD_RENDER_URL="https://ize.onrender.com" # points to same app deployment as prod_url
 
 ## Alchemy
-ALCHEMY_API_KEY_ETHEREUM="get_a_key"
-ALCHEMY_API_KEY_OPTIMISM="get_a_key"
-ALCHEMY_API_KEY_POLYGON="get_a_key"
-ALCHEMY_API_KEY_ARBITRUM="get_a_key"
-ALCHEMY_API_KEY_BASE="get_a_key"
-
+ALCHEMY_API_KEY="get_a_key"
 DATABASE_URL="postgresql://<username>@localhost:5432/izedev" 
 # there are seperate dev and prod discord apps
 DISCORD_IZE_BOT_API_TOKEN="get_a_key"

--- a/apps/backend/src/blockchain/alchemyClient/AlchemyMultichainClient.ts
+++ b/apps/backend/src/blockchain/alchemyClient/AlchemyMultichainClient.ts
@@ -59,7 +59,10 @@ export class AlchemyMultichainClient {
         this.overrides && this.overrides[network]
           ? { ...this.overrides[network], network }
           : { ...this.settings, network };
-      this.instances.set(network, new Alchemy(alchemySettings));
+      this.instances.set(
+        network,
+        new Alchemy({ apiKey: process.env.ALCHEMY_API_KEY, ...alchemySettings }),
+      );
     }
     return this.instances.get(network) as Alchemy;
   }

--- a/render.yaml
+++ b/render.yaml
@@ -54,15 +54,7 @@ envVarGroups:
         sync: false
       - key: OPEN_AI_KEY
         sync: false
-      - key: ALCHEMY_API_KEY_ETHEREUM
-        sync: false
-      - key: ALCHEMY_API_KEY_BASE
-        sync: false
-      - key: ALCHEMY_API_KEY_POLYGON
-        sync: false
-      - key: ALCHEMY_API_KEY_ARBITRUM
-        sync: false
-      - key: ALCHEMY_API_KEY_OPTIMISM
+      - key: ALCHEMY_API_KEY
         sync: false
       - key: STYTCH_PROJECT_ID
         sync: false


### PR DESCRIPTION
Previously Alchemy had different api keys for each chain. 